### PR TITLE
Make maxTup and minTup strict to avoid high memory usage.

### DIFF
--- a/src/Data/Sparse/Utils.hs
+++ b/src/Data/Sparse/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Data.Sparse.Utils (unionWithD, intersectWithD, indexed, indexed2, minTup, maxTup, LB, UB, inBounds0, inBounds02, sortWith) where
 
 -- import Control.Arrow (first, second)
@@ -83,8 +85,8 @@ safe q f v | q v = Nothing
 -- | Componentwise tuple operations
 -- TODO : use semilattice properties instead
 maxTup, minTup :: Ord t => (t, t) -> (t, t) -> (t, t)
-maxTup (x1,y1) (x2,y2) = (max x1 x2, max y1 y2)
-minTup (x1,y1) (x2,y2) = (min x1 x2, min y1 y2)
+maxTup (!x1,!y1) (!x2,!y2) = (max x1 x2, max y1 y2)
+minTup (!x1,!y1) (!x2,!y2) = (min x1 x2, min y1 y2)
 
 
 


### PR DESCRIPTION
When running with low stack size, there was high usage in maxTup. Making these functions strict removes stack issues containing `^+^`.