### PR TITLE
Generally add strictness and utility function unsafeMkSp

### DIFF
--- a/src/Data/Sparse/Internal/IntM.hs
+++ b/src/Data/Sparse/Internal/IntM.hs
@@ -1,4 +1,4 @@
-{-# language DeriveFunctor, DeriveFoldable, TypeFamilies #-}
+{-# language DeriveFunctor, DeriveFoldable, TypeFamilies, BangPatterns #-}
 module Data.Sparse.Internal.IntM where
 
 import Data.Sparse.Utils
@@ -58,7 +58,7 @@ findMin (IntM im) = IM.findMin im
 findMax (IntM im) = IM.findMax im
 
 (!) :: IntM a -> IM.Key -> a
-(IntM im) ! i = im IM.! i
+(!) (IntM im) i = im IM.! i
 
 
 instance IsList (IntM a) where
@@ -69,8 +69,8 @@ instance IsList (IntM a) where
 
 
 instance Set IntM where
-  liftU2 f (IntM a) (IntM b) = IntM $ IM.unionWith f a b
-  liftI2 f (IntM a) (IntM b) = IntM $ IM.intersectionWith f a b
+  liftU2 f (IntM !a) (IntM !b) = IntM $ IM.unionWith f a b
+  liftI2 f (IntM !a) (IntM !b) = IntM $ IM.intersectionWith f a b
 
 
 instance AdditiveGroup a => AdditiveGroup (IntM a) where

--- a/src/Data/Sparse/Internal/IntM.hs
+++ b/src/Data/Sparse/Internal/IntM.hs
@@ -8,13 +8,17 @@ import GHC.Exts
 import Data.Complex
 
 import qualified Data.IntMap.Strict as IM
+import qualified Data.IntMap.Merge.Strict as IM
 
 
 
 
 
 -- | A synonym for IntMap 
-newtype IntM a = IntM {unIM :: IM.IntMap a} deriving (Eq, Show, Functor, Foldable)
+newtype IntM a = IntM {unIM :: IM.IntMap a} deriving (Eq, Show, Foldable)
+
+instance Functor IntM where
+  fmap f (IntM m) = IntM $! IM.map f m
 
 empty :: IntM a
 empty = IntM IM.empty
@@ -69,8 +73,8 @@ instance IsList (IntM a) where
 
 
 instance Set IntM where
-  liftU2 f (IntM !a) (IntM !b) = IntM $ IM.unionWith f a b
-  liftI2 f (IntM !a) (IntM !b) = IntM $ IM.intersectionWith f a b
+  liftU2 f (IntM !a) (IntM !b) = IntM $! IM.unionWith f a b
+  liftI2 f (IntM !a) (IntM !b) = IntM $! IM.intersectionWith f a b
 
 
 instance AdditiveGroup a => AdditiveGroup (IntM a) where

--- a/src/Data/Sparse/Internal/IntMap2.hs
+++ b/src/Data/Sparse/Internal/IntMap2.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Data.Sparse.Internal.IntMap2 where
 
 import qualified Data.Sparse.Internal.IntM as I
@@ -63,8 +65,8 @@ ifoldlIM2' f empty mm = I.foldlWithKey' accRow empty mm where
 --   IM.IntMap (IM.IntMap t) ->  
 --   IM.IntMap a
 ifoldlIM2 f m         = I.foldlWithKey' accRow I.empty m where
-  accRow    acc i row = I.foldlWithKey' (accElem i) acc row
-  accElem i acc j x   = f i j x acc
+  accRow    !acc i row = I.foldlWithKey' (accElem i) acc row
+  accElem i !acc j x   = f i j x acc
 {-# inline ifoldlIM2 #-}  
 
 -- |Left fold over an IM2, with general accumulator

--- a/src/Data/Sparse/Internal/IntMap2.hs
+++ b/src/Data/Sparse/Internal/IntMap2.hs
@@ -8,6 +8,7 @@ import qualified Data.Sparse.Internal.IntM as I
 import qualified Data.IntMap.Strict as IM
 import Data.Sparse.Types
 
+import Data.List (foldl')
 import Data.Maybe
 import GHC.Exts
 
@@ -24,8 +25,8 @@ import GHC.Exts
 insertIM2
   :: IM.Key -> IM.Key -> a -> I.IntM (I.IntM a) -> I.IntM (I.IntM a)
 insertIM2 i j x (I.IntM imm) = I.IntM $ IM.alter ro i imm where
-  ro Nothing = Just $ I.singleton j x
-  ro (Just m) = Just $ I.insert j x m
+  ro Nothing = Just $! I.singleton j x
+  ro (Just m) = Just $! I.insert j x m
 {-# inline insertIM2 #-}
 
 -- * Lookup
@@ -47,7 +48,7 @@ lookupWD_IM im (i,j) = fromMaybe 0 (IM.lookup i im >>= IM.lookup j)
 -- fromListIM2 ::
 --   Foldable t =>
 --      t (IM.Key, IM.Key, a) -> IM.IntMap (IM.IntMap a) -> IM.IntMap (IM.IntMap a)
-fromListIM2 iix sm = foldl ins sm iix where
+fromListIM2 iix sm = foldl' ins sm iix where
   ins t (i,j,x) = insertIM2 i j x t
 
 
@@ -72,8 +73,8 @@ ifoldlIM2 f m         = I.foldlWithKey' accRow I.empty m where
 
 -- |Left fold over an IM2, with general accumulator
 -- foldlIM2 :: (a -> b -> b) -> b -> IM.IntMap (IM.IntMap a) -> b
-foldlIM2 f empty mm = foldl accRow empty mm where
-  accRow acc r = foldl accElem acc r
+foldlIM2 f empty mm = foldl' accRow empty mm where
+  accRow acc r = foldl' accElem acc r
   accElem acc x = f x acc
 {-# inline foldlIM2 #-}
 

--- a/src/Data/Sparse/Internal/TriMatrix.hs
+++ b/src/Data/Sparse/Internal/TriMatrix.hs
@@ -218,7 +218,7 @@ lStep amat lmat umat udiag j = foldr ins lmat [j .. m-1] where
 
 
 fillSM :: (Rows, Cols) -> Bool -> IM.IntMap (SList a) -> SpMatrix a
-fillSM (m,n) transpq tm = IM.foldlWithKey rowIns (zeroSM m n) tm where
+fillSM (m,n) transpq tm = IM.foldlWithKey' rowIns (zeroSM m n) tm where
   rowIns accRow i row = foldr ins accRow (unSL row) where
     ins (j, x) acc | transpq = insertSpMatrix j i x acc   -- transposed fill
                    | otherwise = insertSpMatrix i j x acc

--- a/src/Data/Sparse/SpVector.hs
+++ b/src/Data/Sparse/SpVector.hs
@@ -280,7 +280,7 @@ fromListSV d iix = SV d $ foldr insf empty iix where
 
 
 createv :: [a] -> SpVector a
-createv ll = fromListSV n $ indexed ll where n = length ll
+createv ll = SV n . fromList $ indexed ll where n = length ll
 
 -- | Create a /dense/ SpVector from a list of Double's
 vr :: [Double] -> SpVector Double 
@@ -306,7 +306,7 @@ toDenseListSV (SV d (IntM im)) = fmap (\i -> IM.findWithDefault 0 i im) [0 .. d-
 
 -- | Indexed fold over SpVector
 ifoldSV :: (IM.Key -> a -> b -> b) -> b -> SpVector a -> b
-ifoldSV f e (SV _ (IntM im)) = IM.foldrWithKey f e im
+ifoldSV f e (SV _ (IntM im)) = IM.foldrWithKey' f e im
 
 
 

--- a/src/Data/Sparse/Utils.hs
+++ b/src/Data/Sparse/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Data.Sparse.Utils (unionWithD, intersectWithD, indexed, indexed2, minTup, maxTup, LB, UB, inBounds0, inBounds02, sortWith) where
 
 -- import Control.Arrow (first, second)
@@ -83,8 +85,8 @@ safe q f v | q v = Nothing
 -- | Componentwise tuple operations
 -- TODO : use semilattice properties instead
 maxTup, minTup :: Ord t => (t, t) -> (t, t) -> (t, t)
-maxTup (x1,y1) (x2,y2) = (max x1 x2, max y1 y2)
-minTup (x1,y1) (x2,y2) = (min x1 x2, min y1 y2)
+maxTup (!x1,!y1) (!x2,!y2) = (max x1 x2, max y1 y2)
+minTup (!x1,!y1) (!x2,!y2) = (min x1 x2, min y1 y2)
 
 
 


### PR DESCRIPTION
I would be very careful with this request and possibly cherry pick, but following http://neilmitchell.blogspot.com/2015/09/detecting-space-leaks.html I was able to pinpoint several locations where stack overflows occurred. Mainly seemed to be due to lazy `fmap` (as noted in `Data.IntMap.Strict` documentation, some `foldl`s instead of `foldl'`s, and the like. There is definitely some redundancy with the bang patterns, so many may be extra (but did not result in any issues that I saw).

I also included the previous pull requests, so I'll delete those.

There's also a new function `unsafeMkSp` as `IntM` is not exposed, but for using libraries such as `Control.Foldl` I needed to somehow convert the raw `IntMap (IntMap a)` to be used.

Right now I'm unable to find additional locations, however, as I get stuck at `liftI2` as a stack overflow but `containers` maintains that there is no issue with `intersectionWith`, so I don't know where else to look.