### PR TITLE
Expose imapSM, correct imapIM2, and change to alter

### DIFF
--- a/src/Data/Sparse/Internal/IntMap2.hs
+++ b/src/Data/Sparse/Internal/IntMap2.hs
@@ -6,6 +6,7 @@ import qualified Data.Sparse.Internal.IntM as I
 import qualified Data.IntMap.Strict as IM
 import Data.Sparse.Types
 
+import Data.List (foldl')
 import Data.Maybe
 import GHC.Exts
 
@@ -70,8 +71,8 @@ ifoldlIM2 f m         = I.foldlWithKey' accRow I.empty m where
 
 -- |Left fold over an IM2, with general accumulator
 -- foldlIM2 :: (a -> b -> b) -> b -> IM.IntMap (IM.IntMap a) -> b
-foldlIM2 f empty mm = foldl accRow empty mm where
-  accRow acc r = foldl accElem acc r
+foldlIM2 f empty mm = foldl' accRow empty mm where
+  accRow acc r = foldl' accElem acc r
   accElem acc x = f x acc
 {-# inline foldlIM2 #-}
 

--- a/src/Data/Sparse/Internal/IntMap2.hs
+++ b/src/Data/Sparse/Internal/IntMap2.hs
@@ -143,7 +143,7 @@ mapIM2 = fmap . fmap
 --   IM.IntMap (IM.IntMap a) ->
 --   IM.IntMap (IM.IntMap b)
 imapIM2 f im = I.mapWithKey ff im where
-  ff j x = I.mapWithKey (`f` j) x
+  ff i x = I.mapWithKey (\j -> f i j) x
 
 
 

--- a/src/Data/Sparse/Internal/IntMap2.hs
+++ b/src/Data/Sparse/Internal/IntMap2.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 module Data.Sparse.Internal.IntMap2 where
 
 import qualified Data.Sparse.Internal.IntM as I
@@ -65,8 +67,8 @@ ifoldlIM2' f empty mm = I.foldlWithKey' accRow empty mm where
 --   IM.IntMap (IM.IntMap t) ->  
 --   IM.IntMap a
 ifoldlIM2 f m         = I.foldlWithKey' accRow I.empty m where
-  accRow    acc i row = I.foldlWithKey' (accElem i) acc row
-  accElem i acc j x   = f i j x acc
+  accRow    !acc !i !row = I.foldlWithKey' (accElem i) acc row
+  accElem !i !acc !j !x   = f i j x acc
 {-# inline ifoldlIM2 #-}  
 
 -- |Left fold over an IM2, with general accumulator

--- a/src/Data/Sparse/SpMatrix.hs
+++ b/src/Data/Sparse/SpMatrix.hs
@@ -242,8 +242,8 @@ fromListDenseSM m ll = fromListSM (m, n) $ indexed2 m ll where
 
 -- | Return the SpMatrix from the dimensions and internal IntMap of IntMap
 -- representation.
-unsafeFromImmSM' :: (Int, Int) -> IM.IntMap (IM.IntMap a) -> SpMatrix a
-unsafeFromImmSM' dims m = SM dims . IntM . fmap IntM $ m
+unsafeFromImmSM :: (Int, Int) -> IM.IntMap (IM.IntMap a) -> SpMatrix a
+unsafeFromImmSM dims m = SM dims . IntM . fmap IntM $ m
 
 -- ** toList
 

--- a/src/Data/Sparse/SpMatrix.hs
+++ b/src/Data/Sparse/SpMatrix.hs
@@ -594,7 +594,10 @@ fromBlocksDiag mml = fromListSM (n, n) lstot where
 ifilterSM :: (IM.Key -> IM.Key -> a -> Bool) -> SpMatrix a -> SpMatrix a
 ifilterSM f (SM d im) = SM d $ ifilterIM2 f im
 
- 
+-- | Indexed map over SpMatrix
+{-# INLINE imapSM #-}
+imapSM :: (IM.Key -> IM.Key -> a -> b) -> SpMatrix a -> SpMatrix b
+imapSM f (SM d im) = SM d $ imapIM2 f im
 
 -- | Left fold over SpMatrix
 {-# INLINE foldlSM #-}

--- a/src/Data/Sparse/SpMatrix.hs
+++ b/src/Data/Sparse/SpMatrix.hs
@@ -1,5 +1,5 @@
 {-# language FlexibleInstances, FlexibleContexts, TypeFamilies #-}
-{-# language DeriveFunctor, DeriveFoldable #-}
+{-# language DeriveFunctor, DeriveFoldable, BangPatterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2016 Marco Zocca
@@ -217,7 +217,7 @@ insertSpMatrix i j x s
 -- | Add to existing SpMatrix using data from list (row, col, value)
 fromListSM' :: Foldable t => t (IxRow, IxCol, a) -> SpMatrix a -> SpMatrix a
 fromListSM' iix sm = foldl' ins sm iix where
-  ins t (i,j,x) = insertSpMatrix i j x t
+  ins t (!i,!j,!x) = insertSpMatrix i j x t
 
 -- | Create new SpMatrix using data from a Foldable (e.g. a list) in (row, col, value) form
 fromListSM :: Foldable t => (Int, Int) -> t (IxRow, IxCol, a) -> SpMatrix a

--- a/src/Data/Sparse/SpMatrix.hs
+++ b/src/Data/Sparse/SpMatrix.hs
@@ -1,5 +1,5 @@
 {-# language FlexibleInstances, FlexibleContexts, TypeFamilies #-}
-{-# language DeriveFunctor, DeriveFoldable, BangPatterns #-}
+{-# language DeriveFunctor, DeriveFoldable #-}
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2016 Marco Zocca
@@ -217,7 +217,7 @@ insertSpMatrix i j x s
 -- | Add to existing SpMatrix using data from list (row, col, value)
 fromListSM' :: Foldable t => t (IxRow, IxCol, a) -> SpMatrix a -> SpMatrix a
 fromListSM' iix sm = foldl' ins sm iix where
-  ins t (!i,!j,!x) = insertSpMatrix i j x t
+  ins t (i,j,x) = insertSpMatrix i j x t
 
 -- | Create new SpMatrix using data from a Foldable (e.g. a list) in (row, col, value) form
 fromListSM :: Foldable t => (Int, Int) -> t (IxRow, IxCol, a) -> SpMatrix a
@@ -240,6 +240,10 @@ fromListDenseSM :: Int -> [a] -> SpMatrix a
 fromListDenseSM m ll = fromListSM (m, n) $ indexed2 m ll where
   n = length ll `div` m
 
+-- | Return the SpMatrix from the dimensions and internal IntMap of IntMap
+-- representation.
+unsafeFromImmSM' :: (Int, Int) -> IM.IntMap (IM.IntMap a) -> SpMatrix a
+unsafeFromImmSM' dims m = SM dims . IntM . fmap IntM $ m
 
 -- ** toList
 


### PR DESCRIPTION
`imapSM` is needed for many processes and is much better than flattening then building the matrix again to map over indices. I fixed the `imapIM2` issue referenced in #74 and changed `insert` to `alter` for more speedup and better memory usage.